### PR TITLE
Vectorize colosseum_v2 environments for CUDA multi-env support

### DIFF
--- a/mani_skill/envs/tasks/tabletop/colosseum_v2/cook_item_in_pan.py
+++ b/mani_skill/envs/tasks/tabletop/colosseum_v2/cook_item_in_pan.py
@@ -282,9 +282,10 @@ class CookItemInPanEnv(BaseEnv):
             env=self, robot_init_qpos_noise=self.robot_init_qpos_noise
         )
         self.table_scene.build()
-        self.table_surface_z = float(
-            self.table_scene.table.pose.p[0, 2] + self.table_scene.table_height
-        )
+        # Use underlying SAPIEN object to get table Z since GPU sim is not yet initialized
+        raw_table = self.table_scene.table._objs[0]
+        table_z = float(raw_table.pose.p[2])
+        self.table_surface_z = table_z + float(self.table_scene.table_height)
 
         self.stove = self._build_stove()
         self.pan = self._build_pan()

--- a/mani_skill/envs/tasks/tabletop/colosseum_v2/hammer_nail.py
+++ b/mani_skill/envs/tasks/tabletop/colosseum_v2/hammer_nail.py
@@ -386,6 +386,9 @@ class HammerNailEnv(BaseEnv):
             nail = builder.build_dynamic(name=spec.name)
             nail.set_linear_damping(2.0)
             nail.set_angular_damping(5.0)
+            # Lock X and Z linear movement, allow only Y; lock all rotations.
+            # Must be set before GPU sim initialization.
+            nail.set_locked_motion_axes([True, False, True, True, True, True])
             self.nails.append(nail)
 
             rest_center = torch.from_numpy(spec.rest_center).to(torch.float32)
@@ -477,7 +480,8 @@ class HammerNailEnv(BaseEnv):
         self._choose_hammer_orientation()
         self._apply_hammer_z_rotation(-90.0)
         self._update_hammer_rest_height()
-        self.hammer.set_pose(
+        # Use underlying SAPIEN object since GPU sim is not yet initialized
+        self.hammer._objs[0].set_pose(
             sapien.Pose(
                 p=self._hammer_rest_center.tolist(),
                 q=self._hammer_orientation.tolist(),
@@ -521,7 +525,9 @@ class HammerNailEnv(BaseEnv):
     def _choose_hammer_orientation(self):
         import sapien.render
 
-        render_comp = self.hammer._objs[0].find_component_by_type(
+        # Use underlying SAPIEN object directly since GPU sim is not yet initialized
+        raw_hammer = self.hammer._objs[0]
+        render_comp = raw_hammer.find_component_by_type(
             sapien.render.RenderBodyComponent
         )
         if render_comp is None:
@@ -537,7 +543,7 @@ class HammerNailEnv(BaseEnv):
         best_q = candidates[0]
         best_extent = None
         for q in candidates:
-            self.hammer.set_pose(sapien.Pose(p=[0.0, 0.0, 0.0], q=q.tolist()))
+            raw_hammer.set_pose(sapien.Pose(p=[0.0, 0.0, 0.0], q=q.tolist()))
             aabb = render_comp.compute_global_aabb_tight()
             z_extent = float(aabb[1, 2] - aabb[0, 2])
             if best_extent is None or z_extent < best_extent:
@@ -548,13 +554,15 @@ class HammerNailEnv(BaseEnv):
     def _update_hammer_rest_height(self):
         import sapien.render
 
-        render_comp = self.hammer._objs[0].find_component_by_type(
+        # Use underlying SAPIEN object directly since GPU sim is not yet initialized
+        raw_hammer = self.hammer._objs[0]
+        render_comp = raw_hammer.find_component_by_type(
             sapien.render.RenderBodyComponent
         )
         if render_comp is None:
             return
 
-        self.hammer.set_pose(
+        raw_hammer.set_pose(
             sapien.Pose(p=[0.0, 0.0, 0.0], q=self._hammer_orientation.tolist())
         )
         aabb = render_comp.compute_global_aabb_tight()
@@ -605,10 +613,6 @@ class HammerNailEnv(BaseEnv):
                 nail.set_pose(pose)
                 nail.set_linear_velocity(torch.zeros((b, 3), device=self.device))
                 nail.set_angular_velocity(torch.zeros((b, 3), device=self.device))
-
-                # Lock X and Z linear movement, allow only Y movement, lock all rotations
-                # [lock_x, lock_y, lock_z, lock_rot_x, lock_rot_y, lock_rot_z]
-                nail.set_locked_motion_axes(torch.tensor([[True, False, True, True, True, True]] * b, device=self.device))
 
             # Randomize hammer position
             hammer_pos = self._hammer_rest_center.to(self.device).unsqueeze(0).repeat(b, 1)

--- a/mani_skill/envs/tasks/tabletop/colosseum_v2/open_cabinet.py
+++ b/mani_skill/envs/tasks/tabletop/colosseum_v2/open_cabinet.py
@@ -253,16 +253,16 @@ class OpenCabinetEnv(BaseEnv):
             name="handle_link",
         )
 
-        # Store handle position relative to link
+        # Store handle position relative to link (single model, replicated for all envs)
+        handle_pos_list = [
+            meshes[link_ids[i] % len(meshes)].bounding_box.center_mass
+            if meshes[link_ids[i] % len(meshes)] is not None
+            else [0, 0, 0]
+            for i, meshes in enumerate(handle_links_meshes)
+        ]
+        # Expand to num_envs (single model replicated across all parallel envs)
         self.handle_link_pos = common.to_tensor(
-            np.array(
-                [
-                    meshes[link_ids[i] % len(meshes)].bounding_box.center_mass
-                    if meshes[link_ids[i] % len(meshes)] is not None
-                    else [0, 0, 0]
-                    for i, meshes in enumerate(handle_links_meshes)
-                ]
-            ),
+            np.array(handle_pos_list * self.num_envs),
             device=self.device,
         )
 
@@ -277,11 +277,14 @@ class OpenCabinetEnv(BaseEnv):
         )
 
     def _after_reconfigure(self, options):
-        self.cabinet_zs = []
+        cabinet_zs = []
         for cabinet in self._cabinets:
             collision_mesh = cabinet.get_first_collision_mesh()
-            self.cabinet_zs.append(-collision_mesh.bounding_box.bounds[0, 2])
-        self.cabinet_zs = common.to_tensor(self.cabinet_zs, device=self.device)
+            cabinet_zs.append(-collision_mesh.bounding_box.bounds[0, 2])
+        # Expand to num_envs (single model replicated across all parallel envs)
+        self.cabinet_zs = common.to_tensor(
+            cabinet_zs * self.num_envs, device=self.device
+        )
 
         target_qlimits = self.handle_link.joint.limits
         qmin, qmax = target_qlimits[..., 0], target_qlimits[..., 1]
@@ -330,7 +333,9 @@ class OpenCabinetEnv(BaseEnv):
                 self.scene.px.step()
                 self.scene._gpu_fetch_all()
 
-            handle_pos = self.handle_link_positions(env_idx)[0].cpu().numpy()
+            # Get handle position from first env for grasp computation (all envs share the same cabinet model)
+            handle_pos_all = self.handle_link_positions(env_idx)
+            handle_pos = handle_pos_all[0].cpu().numpy() if handle_pos_all.ndim >= 2 else handle_pos_all.cpu().numpy()
 
             # Compute grasp pose using EXACT same logic as motion planning solution
             # Get joint info

--- a/mani_skill/envs/tasks/tabletop/colosseum_v2/pick_cube_from_drawer.py
+++ b/mani_skill/envs/tasks/tabletop/colosseum_v2/pick_cube_from_drawer.py
@@ -176,15 +176,15 @@ class PickCubeFromDrawerEnv(BaseEnv):
             name="handle_link",
         )
 
+        handle_pos_list = [
+            meshes[link_ids[i] % len(meshes)].bounding_box.center_mass
+            if meshes[link_ids[i] % len(meshes)] is not None
+            else [0, 0, 0]
+            for i, meshes in enumerate(handle_links_meshes)
+        ]
+        # Expand to num_envs (single model replicated across all parallel envs)
         self.handle_link_pos = common.to_tensor(
-            np.array(
-                [
-                    meshes[link_ids[i] % len(meshes)].bounding_box.center_mass
-                    if meshes[link_ids[i] % len(meshes)] is not None
-                    else [0, 0, 0]
-                    for i, meshes in enumerate(handle_links_meshes)
-                ]
-            ),
+            np.array(handle_pos_list * self.num_envs),
             device=self.device,
         )
 
@@ -205,11 +205,14 @@ class PickCubeFromDrawerEnv(BaseEnv):
                     joint.set_drive_properties(stiffness=100.0, damping=50.0)
 
     def _after_reconfigure(self, options):
-        self.cabinet_zs = []
+        cabinet_zs = []
         for cabinet in self._cabinets:
             collision_mesh = cabinet.get_first_collision_mesh()
-            self.cabinet_zs.append(-collision_mesh.bounding_box.bounds[0, 2])
-        self.cabinet_zs = common.to_tensor(self.cabinet_zs, device=self.device)
+            cabinet_zs.append(-collision_mesh.bounding_box.bounds[0, 2])
+        # Expand to num_envs (single model replicated across all parallel envs)
+        self.cabinet_zs = common.to_tensor(
+            cabinet_zs * self.num_envs, device=self.device
+        )
 
         target_qlimits = self.handle_link.joint.limits
         qmin, qmax = target_qlimits[..., 0], target_qlimits[..., 1]

--- a/mani_skill/envs/tasks/tabletop/colosseum_v2/pick_dish_from_rack.py
+++ b/mani_skill/envs/tasks/tabletop/colosseum_v2/pick_dish_from_rack.py
@@ -10,13 +10,21 @@ from sapien.physx import PhysxMaterial
 from mani_skill import PACKAGE_ASSET_DIR
 from mani_skill.agents.robots import Fetch, Panda
 from mani_skill.envs.sapien_env import BaseEnv
+from mani_skill.envs.utils import randomization
 from mani_skill.sensors.camera import CameraConfig
 from mani_skill.utils import sapien_utils
+from mani_skill.utils.geometry.rotation_conversions import quaternion_to_matrix
 from mani_skill.utils.registration import register_env
 from mani_skill.utils.scene_builder.table import TableSceneBuilder
 from mani_skill.utils.structs.pose import Pose
 from mani_skill.utils.structs.types import GPUMemoryConfig, SimConfig
-from mani_skill.envs.distraction_set import DistractionSet
+from sapien.physx import PhysxRigidDynamicComponent
+try:  # Optional dependency for convex decomposition
+    import coacd  # noqa: F401
+
+    _HAS_COACD = True
+except ImportError:
+    _HAS_COACD = False
 
 logger = logging.getLogger(__name__)
 
@@ -73,8 +81,6 @@ class PickDishFromRackEnv(BaseEnv):
     _rack_y_ranges = [(-0.25, -0.15), (0.15, 0.25)]
 
     def __init__(self, *args, robot_uids="panda", robot_init_qpos_noise=0.02, **kwargs):
-        distraction_set: DistractionSet | dict | None = kwargs.pop("distraction_set", None)
-        self._distraction_set: DistractionSet | None = DistractionSet(**distraction_set) if isinstance(distraction_set, dict) else distraction_set
         self.robot_init_qpos_noise = robot_init_qpos_noise
         super().__init__(*args, robot_uids=robot_uids, **kwargs)
 
@@ -127,6 +133,7 @@ class PickDishFromRackEnv(BaseEnv):
 
         self.plate = self._build_plate()
         self.dish_rack = self._build_rack()
+        self._plate_gravity_enabled = False
 
     def _build_plate(self):
         """Build the plate directly from the high-fidelity ceramic bowl mesh."""
@@ -143,14 +150,28 @@ class PickDishFromRackEnv(BaseEnv):
         )
         mesh_pose = sapien.Pose(q=self._plate_mesh_flat_quat)
 
-        builder.add_multiple_convex_collisions_from_file(
-            filename=str(self._plate_visual_mesh_path),
-            scale=[collision_scale, collision_scale, collision_scale],
-            pose=mesh_pose,
-            material=physical_material,
-            density=self._plate_density,
-            decomposition="coacd",
-        )
+        if _HAS_COACD:
+            builder.add_multiple_convex_collisions_from_file(
+                filename=str(self._plate_visual_mesh_path),
+                scale=[collision_scale, collision_scale, collision_scale],
+                pose=mesh_pose,
+                material=physical_material,
+                density=self._plate_density,
+                decomposition="coacd",
+            )
+        else:
+            logger.warning(
+                "coacd not installed; falling back to nonconvex collision for plate. "
+                "Run `pip install coacd` for better plate contacts."
+            )
+            builder.add_nonconvex_collision_from_file(
+                filename=str(self._plate_visual_mesh_path),
+                scale=[collision_scale, collision_scale, collision_scale],
+                pose=mesh_pose,
+                material=physical_material,
+                density=self._plate_density,
+            )
+
         plate_visual_material = sapien.render.RenderMaterial(
             base_color=[1.0, 1.0, 1.0, 1.0],
             specular=0.4,
@@ -167,7 +188,6 @@ class PickDishFromRackEnv(BaseEnv):
 
         builder.initial_pose = sapien.Pose()
         return builder.build(name="plate")
-
 
     def _build_rack(self):
         builder = self.scene.create_actor_builder()
@@ -211,71 +231,130 @@ class PickDishFromRackEnv(BaseEnv):
         return builder.build_kinematic(name="dish_rack")
 
     def _initialize_episode(self, env_idx: torch.Tensor, options: Dict):
-        with torch.device(self.device):
+        device = self.device
+        with torch.device(device):
             b = len(env_idx)
 
-            # Initialize table scene with default qpos
-            self.table_scene.initialize(env_idx)
-
             # Get table top Z coordinate
-            table_p = self.table_scene.table.pose.p
-            if table_p.ndim == 2:
-                table_z = table_p[0, 2]
-            else:
-                table_z = table_p[2]
-            table_top_z = float(table_z) + float(self.table_scene.table_height)
+            table_p_arr = np.asarray(self.table_scene.table.pose.p.cpu()).ravel()
+
+            table_z = float(table_p_arr[-1])
+            table_top_z = table_z + float(self.table_scene.table_height)
 
             # Position rack on table with Y randomization (symmetric around robot)
-            rack_pos = torch.zeros((b, 3), device=self.device)
+            rack_pos = torch.zeros((b, 3), device=device)
             rack_pos[:, 0] = self._rack_position[0]  # Fixed X
-
-            # Vectorized: randomly pick left or right Y range, then sample within
-            y_mins = torch.tensor(
-                [r[0] for r in self._rack_y_ranges], device=self.device
-            )
-            y_maxs = torch.tensor(
-                [r[1] for r in self._rack_y_ranges], device=self.device
-            )
-            range_idx = torch.randint(0, len(self._rack_y_ranges), (b,), device=self.device)
-            chosen_mins = y_mins[range_idx]
-            chosen_maxs = y_maxs[range_idx]
-            rack_pos[:, 1] = (
-                torch.rand(b, device=self.device) * (chosen_maxs - chosen_mins)
-                + chosen_mins
-            )
+            # Randomly pick left or right range, then sample within that range
+            for i in range(b):
+                # Pick random range (0 = left/negative, 1 = right/positive)
+                range_idx = torch.randint(0, 2, (1,)).item()
+                y_min, y_max = self._rack_y_ranges[range_idx]
+                rack_pos[i, 1] = torch.rand(1, device=device).item() * (y_max - y_min) + y_min
             rack_pos[:, 2] = table_top_z + float(self._rack_extent[2])
+
+            # Compute EE target position above rack center (for grasp approach)
+            # EE should be above the plate which is at rack center, at the top of the vertical plate
+            ee_target_x = rack_pos[0, 0].item()
+            ee_target_y = rack_pos[0, 1].item()
+            ee_target_z = table_top_z + self._plate_outer_radius * 2 + 0.25  # Above plate top + higher clearance
+
+            # Use IK to find qpos that places EE at target position
+            # Grasp pose: approaching from above (-Z), closing in Y direction
+            from mani_skill.examples.motionplanning.panda.motionplanner import PandaArmMotionPlanningSolver
+            import sapien
+
+            # Initialize table scene first with default qpos
+            self.table_scene.initialize(env_idx)
+
+            # Create a temporary planner to compute IK
+            try:
+                planner = PandaArmMotionPlanningSolver(
+                    self,
+                    debug=False,
+                    vis=False,
+                    base_pose=self.agent.robot.pose,
+                    visualize_target_grasp_pose=False,
+                    print_env_info=False,
+                )
+
+                # Build target pose above rack
+                approaching = np.array([0, 0, -1])
+                closing = np.array([0, 1, 0])
+                target_pos = np.array([ee_target_x, ee_target_y, ee_target_z])
+                target_pose = self.agent.build_grasp_pose(approaching, closing, target_pos)
+
+                # Compute IK
+                result = planner.planner.IK(target_pose, self.agent.robot.get_qpos()[0, :7].cpu().numpy())
+                if result["status"] == "Success":
+                    pregrasp_qpos = np.array(result["position"])
+                    # Add gripper open position
+                    pregrasp_qpos = np.append(pregrasp_qpos, [0.04, 0.04])
+                    # Re-initialize with computed qpos
+                    self.table_scene.initialize(env_idx, qpos_0=pregrasp_qpos)
+
+                planner.close()
+            except Exception as e:
+                # If IK fails, just use default initialization
+                pass
 
             rack_pose = Pose.create_from_pq(p=rack_pos)
             self.dish_rack.set_pose(rack_pose)
 
             # Place plate VERTICALLY between the dividers in the rack
             plate_pos = rack_pos.clone()
+            # X,Y same as rack center
 
-            # When plate is vertical (after 90deg rotation around X), its radius extends in Z direction
-            # Position center so bottom is at table level
-            plate_pos[:, 2] = table_top_z + self._plate_outer_radius
+            # When plate is vertical (after 90° rotation around X), its radius extends in Z direction
+            # Bottom of plate = center_z - plate_outer_radius
+            # Position center so bottom is at table level (bottom won't clip through)
+            plate_pos[:, 2] = table_top_z + self._plate_outer_radius  # Center at radius height
 
+            # Plate vertical - normal pointing in +X direction (perpendicular to dividers)
+            # Dividers run in X (left-right), plate face should be perpendicular to Y (front-back)
             # Quaternion for 90deg rotation around X axis to make plate stand vertical
             vertical_quat = torch.tensor(
-                [0.7071068, 0.7071068, 0, 0], device=self.device, dtype=torch.float32
-            ).unsqueeze(0).expand(b, -1)
+                [[0.7071068, 0.7071068, 0, 0]],  # 90 deg around X axis
+                device=device,
+                dtype=torch.float32,
+            ).repeat(b, 1)
 
             plate_pose = Pose.create_from_pq(p=plate_pos, q=vertical_quat)
             self.plate.set_pose(plate_pose)
 
             # Zero velocities so the plate remains stationary until grasped
-            zero_velocity = torch.zeros((b, 3), device=self.device)
+            zero_velocity = torch.zeros((b, 3), device=device)
             self.plate.set_linear_velocity(zero_velocity)
             self.plate.set_angular_velocity(zero_velocity)
 
+            # Save initial pose so we can hold the plate in place each step
+            self._plate_initial_pose = plate_pose
+            self._plate_gravity_enabled = False
+
+    def step(self, action):
+        # Zero plate velocity each step to cancel gravity accumulation,
+        # but do NOT reset pose — the plate must stay physically interactable
+        # so the robot can grasp it.
+        if not self._plate_gravity_enabled:
+            zero_vel = torch.zeros((self.num_envs, 3), device=self.device)
+            self.plate.set_linear_velocity(zero_vel)
+            self.plate.set_angular_velocity(zero_vel)
+
+        obs = super().step(action)
+
+        if (
+            not self._plate_gravity_enabled
+            and bool(self.agent.is_grasping(self.plate).any())
+        ):
+            self._plate_gravity_enabled = True
+
+        return obs
+
     def evaluate(self):
         plate_pos = self.plate.pose.p
-        table_p = self.table_scene.table.pose.p
-        if table_p.ndim == 2:
-            table_z = table_p[0, 2]
-        else:
-            table_z = table_p[2]
-        table_top_z = float(table_z) + float(self.table_scene.table_height)
+        table_p_arr = np.asarray(self.table_scene.table.pose.p.cpu()).ravel()
+
+        table_z = float(table_p_arr[-1])
+        table_top_z = table_z + float(self.table_scene.table_height)
 
         # Check that plate is above table surface
         above_table = plate_pos[:, 2] > table_top_z - 0.01
@@ -299,16 +378,15 @@ class PickDishFromRackEnv(BaseEnv):
         }
 
     def _get_obs_extra(self, info: Dict):
-        obs = dict(tcp_pose=self.agent.tcp.pose.raw_pose)
         plate_pose = self.plate.pose
         rack_pose = self.dish_rack.pose
+        obs = {
+            "plate_pos": plate_pose.p,
+            "plate_quat": plate_pose.q,
+            "rack_pos": rack_pose.p,
+            "rack_quat": rack_pose.q,
+        }
         if "state" in self.obs_mode:
-            obs.update(
-                plate_pos=plate_pose.p,
-                plate_quat=plate_pose.q,
-                rack_pos=rack_pose.p,
-                rack_quat=rack_pose.q,
-            )
             goal_pos = torch.tensor(
                 self._plate_goal_position, device=self.device, dtype=plate_pose.p.dtype
             ).unsqueeze(0).repeat(plate_pose.p.shape[0], 1)

--- a/mani_skill/envs/tasks/tabletop/colosseum_v2/pick_dish_from_rack.py
+++ b/mani_skill/envs/tasks/tabletop/colosseum_v2/pick_dish_from_rack.py
@@ -10,10 +10,8 @@ from sapien.physx import PhysxMaterial
 from mani_skill import PACKAGE_ASSET_DIR
 from mani_skill.agents.robots import Fetch, Panda
 from mani_skill.envs.sapien_env import BaseEnv
-from mani_skill.envs.utils import randomization
 from mani_skill.sensors.camera import CameraConfig
 from mani_skill.utils import sapien_utils
-from mani_skill.utils.geometry.rotation_conversions import quaternion_to_matrix
 from mani_skill.utils.registration import register_env
 from mani_skill.utils.scene_builder.table import TableSceneBuilder
 from mani_skill.utils.structs.pose import Pose
@@ -129,7 +127,6 @@ class PickDishFromRackEnv(BaseEnv):
 
         self.plate = self._build_plate()
         self.dish_rack = self._build_rack()
-        self._plate_gravity_enabled = False
 
     def _build_plate(self):
         """Build the plate directly from the high-fidelity ceramic bowl mesh."""
@@ -214,119 +211,71 @@ class PickDishFromRackEnv(BaseEnv):
         return builder.build_kinematic(name="dish_rack")
 
     def _initialize_episode(self, env_idx: torch.Tensor, options: Dict):
-        device = self.device
-        with torch.device(device):
+        with torch.device(self.device):
             b = len(env_idx)
 
-            # Get table top Z coordinate
-            table_p_arr = np.asarray(self.table_scene.table.pose.p).ravel()
-            table_z = float(table_p_arr[-1])
-            table_top_z = table_z + float(self.table_scene.table_height)
-
-            # Position rack on table with Y randomization (symmetric around robot)
-            rack_pos = torch.zeros((b, 3), device=device)
-            rack_pos[:, 0] = self._rack_position[0]  # Fixed X
-            # Randomly pick left or right range, then sample within that range
-            for i in range(b):
-                # Pick random range (0 = left/negative, 1 = right/positive)
-                range_idx = torch.randint(0, 2, (1,)).item()
-                y_min, y_max = self._rack_y_ranges[range_idx]
-                rack_pos[i, 1] = torch.rand(1, device=device).item() * (y_max - y_min) + y_min
-            rack_pos[:, 2] = table_top_z + float(self._rack_extent[2])
-
-            # Compute EE target position above rack center (for grasp approach)
-            # EE should be above the plate which is at rack center, at the top of the vertical plate
-            ee_target_x = rack_pos[0, 0].item()
-            ee_target_y = rack_pos[0, 1].item()
-            ee_target_z = table_top_z + self._plate_outer_radius * 2 + 0.25  # Above plate top + higher clearance
-
-            # Use IK to find qpos that places EE at target position
-            # Grasp pose: approaching from above (-Z), closing in Y direction
-            from mani_skill.examples.motionplanning.panda.motionplanner import PandaArmMotionPlanningSolver
-            import sapien
-
-            # Initialize table scene first with default qpos
+            # Initialize table scene with default qpos
             self.table_scene.initialize(env_idx)
 
-            # Create a temporary planner to compute IK
-            try:
-                planner = PandaArmMotionPlanningSolver(
-                    self,
-                    debug=False,
-                    vis=False,
-                    base_pose=self.agent.robot.pose,
-                    visualize_target_grasp_pose=False,
-                    print_env_info=False,
-                )
+            # Get table top Z coordinate
+            table_p = self.table_scene.table.pose.p
+            if table_p.ndim == 2:
+                table_z = table_p[0, 2]
+            else:
+                table_z = table_p[2]
+            table_top_z = float(table_z) + float(self.table_scene.table_height)
 
-                # Build target pose above rack
-                approaching = np.array([0, 0, -1])
-                closing = np.array([0, 1, 0])
-                target_pos = np.array([ee_target_x, ee_target_y, ee_target_z])
-                target_pose = self.agent.build_grasp_pose(approaching, closing, target_pos)
+            # Position rack on table with Y randomization (symmetric around robot)
+            rack_pos = torch.zeros((b, 3), device=self.device)
+            rack_pos[:, 0] = self._rack_position[0]  # Fixed X
 
-                # Compute IK
-                result = planner.planner.IK(target_pose, self.agent.robot.get_qpos()[0, :7].cpu().numpy())
-                if result["status"] == "Success":
-                    pregrasp_qpos = np.array(result["position"])
-                    # Add gripper open position
-                    pregrasp_qpos = np.append(pregrasp_qpos, [0.04, 0.04])
-                    # Re-initialize with computed qpos
-                    self.table_scene.initialize(env_idx, qpos_0=pregrasp_qpos)
-
-                planner.close()
-            except Exception as e:
-                # If IK fails, just use default initialization
-                pass
+            # Vectorized: randomly pick left or right Y range, then sample within
+            y_mins = torch.tensor(
+                [r[0] for r in self._rack_y_ranges], device=self.device
+            )
+            y_maxs = torch.tensor(
+                [r[1] for r in self._rack_y_ranges], device=self.device
+            )
+            range_idx = torch.randint(0, len(self._rack_y_ranges), (b,), device=self.device)
+            chosen_mins = y_mins[range_idx]
+            chosen_maxs = y_maxs[range_idx]
+            rack_pos[:, 1] = (
+                torch.rand(b, device=self.device) * (chosen_maxs - chosen_mins)
+                + chosen_mins
+            )
+            rack_pos[:, 2] = table_top_z + float(self._rack_extent[2])
 
             rack_pose = Pose.create_from_pq(p=rack_pos)
             self.dish_rack.set_pose(rack_pose)
 
             # Place plate VERTICALLY between the dividers in the rack
             plate_pos = rack_pos.clone()
-            # X,Y same as rack center
 
-            # When plate is vertical (after 90° rotation around X), its radius extends in Z direction
-            # Bottom of plate = center_z - plate_outer_radius
-            # Position center so bottom is at table level (bottom won't clip through)
-            plate_pos[:, 2] = table_top_z + self._plate_outer_radius  # Center at radius height
+            # When plate is vertical (after 90deg rotation around X), its radius extends in Z direction
+            # Position center so bottom is at table level
+            plate_pos[:, 2] = table_top_z + self._plate_outer_radius
 
-            # Plate vertical - normal pointing in +X direction (perpendicular to dividers)
-            # Dividers run in X (left-right), plate face should be perpendicular to Y (front-back)
             # Quaternion for 90deg rotation around X axis to make plate stand vertical
             vertical_quat = torch.tensor(
-                [[0.7071068, 0.7071068, 0, 0]],  # 90 deg around X axis
-                device=device,
-                dtype=torch.float32,
-            ).repeat(b, 1)
+                [0.7071068, 0.7071068, 0, 0], device=self.device, dtype=torch.float32
+            ).unsqueeze(0).expand(b, -1)
 
             plate_pose = Pose.create_from_pq(p=plate_pos, q=vertical_quat)
             self.plate.set_pose(plate_pose)
 
-            # Keep the plate fixed in the rack until it is grasped
-            self.plate.disable_gravity = True
-
             # Zero velocities so the plate remains stationary until grasped
-            zero_velocity = torch.zeros((b, 3), device=device)
+            zero_velocity = torch.zeros((b, 3), device=self.device)
             self.plate.set_linear_velocity(zero_velocity)
             self.plate.set_angular_velocity(zero_velocity)
-            self._plate_gravity_enabled = False
-
-    def step(self, action):
-        obs = super().step(action)
-        if (
-            not self._plate_gravity_enabled
-            and bool(self.agent.is_grasping(self.plate).any())
-        ):
-            self.plate.disable_gravity = False
-            self._plate_gravity_enabled = True
-        return obs
 
     def evaluate(self):
         plate_pos = self.plate.pose.p
-        table_p_arr = np.asarray(self.table_scene.table.pose.p).ravel()
-        table_z = float(table_p_arr[-1])
-        table_top_z = table_z + float(self.table_scene.table_height)
+        table_p = self.table_scene.table.pose.p
+        if table_p.ndim == 2:
+            table_z = table_p[0, 2]
+        else:
+            table_z = table_p[2]
+        table_top_z = float(table_z) + float(self.table_scene.table_height)
 
         # Check that plate is above table surface
         above_table = plate_pos[:, 2] > table_top_z - 0.01

--- a/mani_skill/envs/tasks/tabletop/colosseum_v2/place_cube_in_drawer.py
+++ b/mani_skill/envs/tasks/tabletop/colosseum_v2/place_cube_in_drawer.py
@@ -181,15 +181,15 @@ class PlaceCubeInDrawerEnv(BaseEnv):
             name="handle_link",
         )
 
+        handle_pos_list = [
+            meshes[link_ids[i] % len(meshes)].bounding_box.center_mass
+            if meshes[link_ids[i] % len(meshes)] is not None
+            else [0, 0, 0]
+            for i, meshes in enumerate(handle_links_meshes)
+        ]
+        # Expand to num_envs (single model replicated across all parallel envs)
         self.handle_link_pos = common.to_tensor(
-            np.array(
-                [
-                    meshes[link_ids[i] % len(meshes)].bounding_box.center_mass
-                    if meshes[link_ids[i] % len(meshes)] is not None
-                    else [0, 0, 0]
-                    for i, meshes in enumerate(handle_links_meshes)
-                ]
-            ),
+            np.array(handle_pos_list * self.num_envs),
             device=self.device,
         )
 
@@ -210,11 +210,14 @@ class PlaceCubeInDrawerEnv(BaseEnv):
                     joint.set_drive_properties(stiffness=0.0, damping=50.0)
 
     def _after_reconfigure(self, options):
-        self.cabinet_zs = []
+        cabinet_zs = []
         for cabinet in self._cabinets:
             collision_mesh = cabinet.get_first_collision_mesh()
-            self.cabinet_zs.append(-collision_mesh.bounding_box.bounds[0, 2])
-        self.cabinet_zs = common.to_tensor(self.cabinet_zs, device=self.device)
+            cabinet_zs.append(-collision_mesh.bounding_box.bounds[0, 2])
+        # Expand to num_envs (single model replicated across all parallel envs)
+        self.cabinet_zs = common.to_tensor(
+            cabinet_zs * self.num_envs, device=self.device
+        )
 
         target_qlimits = self.handle_link.joint.limits
         qmin, qmax = target_qlimits[..., 0], target_qlimits[..., 1]

--- a/mani_skill/envs/tasks/tabletop/colosseum_v2/place_dish_in_rack.py
+++ b/mani_skill/envs/tasks/tabletop/colosseum_v2/place_dish_in_rack.py
@@ -276,23 +276,12 @@ class PlaceDishInRackEnv(BaseEnv):
 
             self.table_scene.initialize(env_idx, qpos_0=panda_qpos_above_plate)
 
-            # Raise table to be reachable
-            table_pose = self.table_scene.table.pose
-            table_p = np.asarray(table_pose.p).ravel()
-            table_q = table_pose.q
-            if torch.is_tensor(table_q):
-                table_q = table_q.cpu().numpy().ravel()
-            else:
-                table_q = np.asarray(table_q).ravel()
-
-            # Apply height offset to bring table into robot's workspace
-            new_table_p = np.array([table_p[0], table_p[1], table_p[2] + self.table_height_offset], dtype=np.float32)
-            new_table_q = np.array(table_q, dtype=np.float32)
-            self.table_scene.table.set_pose(sapien.Pose(p=new_table_p, q=new_table_q))
-
             # Compute table top Z for placing objects
-            table_p_arr = np.asarray(self.table_scene.table.pose.p).ravel()
-            table_z = float(table_p_arr[-1])
+            table_p = self.table_scene.table.pose.p
+            if table_p.ndim == 2:
+                table_z = float(table_p[0, 2].cpu())
+            else:
+                table_z = float(table_p[2].cpu())
             table_top_z = table_z + float(self.table_scene.table_height)
 
             # Set plate position (using pre-computed random values)

--- a/mani_skill/envs/tasks/tabletop/load_dishwasher.py
+++ b/mani_skill/envs/tasks/tabletop/load_dishwasher.py
@@ -1,0 +1,405 @@
+import logging
+from typing import Any, Dict, Union
+
+import numpy as np
+import sapien
+import sapien.render
+import torch
+
+from mani_skill import PACKAGE_ASSET_DIR
+from mani_skill.agents.robots import Fetch, Panda
+from mani_skill.envs.sapien_env import BaseEnv
+from mani_skill.sensors.camera import CameraConfig
+from mani_skill.utils import common, sapien_utils
+from mani_skill.utils.geometry.rotation_conversions import quaternion_to_matrix
+from mani_skill.utils.registration import register_env
+from mani_skill.utils.scene_builder.table import TableSceneBuilder
+from mani_skill.utils.structs.pose import Pose
+from mani_skill.utils.structs import Articulation, Link
+from mani_skill.utils.structs.types import GPUMemoryConfig, SimConfig
+from sapien.physx import PhysxMaterial
+
+try:
+    import coacd
+
+    _HAS_COACD = True
+except ImportError:
+    _HAS_COACD = False
+
+logger = logging.getLogger(__name__)
+
+DISHWASHER_COLLISION_BIT = 30
+
+
+@register_env("LoadDishwasher-v1", max_episode_steps=150)
+class LoadDishwasherEnv(BaseEnv):
+    """
+    **Task Description:**
+    Open the dishwasher drawer (pull out the sliding shelf), then place the plate onto the shelf.
+
+    **Randomizations:**
+    - The plate starts randomly on the table near the robot.
+    - The dishwasher position is slightly randomized on the tabletop.
+
+    **Success Conditions:**
+    - The dishwasher drawer is open (shelf pulled out).
+    - The plate is on the shelf inside the dishwasher.
+    - The plate is released and static.
+    """
+
+    agent: Union[Panda, Fetch]
+
+    # Dishwasher URDF path
+    _dishwasher_urdf_path = PACKAGE_ASSET_DIR / "load_dishwasher/12085/mobility.urdf"
+
+    # Plate mesh paths (reuse from PlaceDishInRack)
+    _plate_visual_mesh_path = (
+        PACKAGE_ASSET_DIR / "dish_into_rack/white_ceramic_serving_bowl.glb"
+    )
+    _plate_mesh_source_radius = 0.5
+    _plate_mesh_source_height = 0.2494586706161499
+    _plate_mesh_flat_quat = [np.sqrt(0.5), np.sqrt(0.5), 0.0, 0.0]
+
+    # Plate geometry parameters
+    _plate_outer_radius = 0.09
+    _plate_density = 300.0
+    _plate_total_height = (
+        _plate_mesh_source_height * (_plate_outer_radius / _plate_mesh_source_radius)
+    )
+    _plate_spawn_buffer = 0.002
+
+    # Dishwasher scale (the original model is large, scale it down)
+    _dishwasher_scale = 0.35
+
+    # Minimum open fraction for the drawer to be considered "open"
+    min_open_frac = 0.7
+
+    def __init__(self, *args, robot_uids="panda", robot_init_qpos_noise=0.02, **kwargs):
+        self.robot_init_qpos_noise = robot_init_qpos_noise
+        super().__init__(*args, robot_uids=robot_uids, **kwargs)
+
+    @property
+    def _default_sim_config(self):
+        return SimConfig(
+            sim_freq=200,
+            control_freq=20,
+            gpu_memory_config=GPUMemoryConfig(
+                found_lost_pairs_capacity=2**23, max_rigid_patch_count=2**17
+            ),
+        )
+
+    @property
+    def _default_sensor_configs(self):
+        pose = sapien_utils.look_at(eye=[0.3, -0.25, 0.35], target=[0.0, 0.0, 0.05])
+        return [
+            CameraConfig(
+                "base_camera",
+                pose=pose,
+                width=128,
+                height=128,
+                fov=np.pi / 2,
+                near=0.01,
+                far=100,
+            )
+        ]
+
+    @property
+    def _default_human_render_camera_configs(self):
+        # Camera behind robot at angle looking towards dishwasher
+        pose = sapien_utils.look_at([-1.0, -0.6, 0.7], [0.0, 0.2, 0.1])
+        return CameraConfig(
+            "render_camera", pose=pose, width=512, height=512, fov=1.0, near=0.01, far=100
+        )
+
+    def _load_agent(self, options: Dict):
+        super()._load_agent(options, sapien.Pose(p=[-0.615, 0, 0]))
+
+    def _get_obs_agent(self):
+        obs = super()._get_obs_agent()
+        for key in ("world__T__ee", "world__T__root"):
+            value = obs.get(key, None)
+            if isinstance(value, torch.Tensor) and value.ndim == 3:
+                obs[key] = value.reshape(value.shape[0], -1)
+        return obs
+
+    def _load_scene(self, options: Dict):
+        self.table_scene = TableSceneBuilder(
+            env=self, robot_init_qpos_noise=self.robot_init_qpos_noise
+        )
+        self.table_scene.build()
+
+        self.table_height_offset = 0.0
+
+        # Load dishwasher
+        self._load_dishwasher()
+
+        # Load plate
+        self.plate = self._build_plate()
+        self.plate.set_linear_damping(5.0)
+        self.plate.set_angular_damping(8.0)
+
+    def _load_dishwasher(self):
+        """Load the dishwasher as an articulated object from URDF."""
+        loader = self.scene.create_urdf_loader()
+        loader.scale = self._dishwasher_scale
+        loader.fix_root_link = True
+        loader.name = "dishwasher-0"
+
+        self._dishwashers = []
+        sapien.set_log_level("off")
+        dishwasher = loader.load(str(self._dishwasher_urdf_path))
+        sapien.set_log_level("warn")
+
+        if dishwasher is None:
+            raise ValueError(f"Failed to load dishwasher URDF from {self._dishwasher_urdf_path}")
+
+        self.remove_from_state_dict_registry(dishwasher)
+
+        # Set collision group
+        for link in dishwasher.links:
+            link.set_collision_group_bit(
+                group=2, bit_idx=DISHWASHER_COLLISION_BIT, bit=1
+            )
+        self._dishwashers.append(dishwasher)
+
+        # Merge into single articulation
+        self.dishwasher = Articulation.merge(self._dishwashers, name="dishwasher")
+        self.add_to_state_dict_registry(self.dishwasher)
+
+        # Find the shelf link (link_1 with prismatic joint)
+        shelf_links = []
+        for link, joint in zip(dishwasher.links, dishwasher.joints):
+            # joint.type can be a string or list depending on wrapper
+            jtype = joint.type[0] if hasattr(joint.type, "__getitem__") and not isinstance(joint.type, str) else joint.type
+            if jtype == "prismatic":
+                shelf_links.append(link)
+
+        if not shelf_links:
+            raise ValueError(f"No prismatic joint found in dishwasher model. Available: {[(j.name, j.type) for j in dishwasher.joints]}")
+
+        self.shelf_link = Link.merge(shelf_links, name="shelf_link")
+
+        # Store the prismatic joint for later use
+        for joint in dishwasher.joints:
+            jtype = joint.type[0] if hasattr(joint.type, "__getitem__") and not isinstance(joint.type, str) else joint.type
+            if jtype == "prismatic":
+                self._drawer_joint = joint
+                break
+
+    def _build_plate(self):
+        """Build the plate from the ceramic bowl mesh."""
+        builder = self.scene.create_actor_builder()
+
+        physical_material = PhysxMaterial(
+            static_friction=20.0,
+            dynamic_friction=20.0,
+            restitution=0.0,
+        )
+
+        collision_scale = float(
+            self._plate_outer_radius / self._plate_mesh_source_radius
+        )
+        mesh_pose = sapien.Pose(q=self._plate_mesh_flat_quat)
+
+        if _HAS_COACD:
+            builder.add_multiple_convex_collisions_from_file(
+                filename=str(self._plate_visual_mesh_path),
+                scale=[collision_scale, collision_scale, collision_scale],
+                pose=mesh_pose,
+                material=physical_material,
+                density=self._plate_density,
+                decomposition="coacd",
+            )
+        else:
+            logger.warning(
+                "coacd not installed; falling back to nonconvex collision for plate."
+            )
+            builder.add_nonconvex_collision_from_file(
+                filename=str(self._plate_visual_mesh_path),
+                scale=[collision_scale, collision_scale, collision_scale],
+                pose=mesh_pose,
+                material=physical_material,
+                density=self._plate_density,
+            )
+
+        plate_visual_material = sapien.render.RenderMaterial(
+            base_color=[1.0, 1.0, 1.0, 1.0],
+            specular=0.4,
+            roughness=0.2,
+            metallic=0.0,
+        )
+
+        builder.add_visual_from_file(
+            filename=str(self._plate_visual_mesh_path),
+            scale=[collision_scale, collision_scale, collision_scale],
+            pose=mesh_pose,
+            material=plate_visual_material,
+        )
+
+        builder.initial_pose = sapien.Pose()
+        return builder.build(name="plate")
+
+    def _after_reconfigure(self, options):
+        # Compute target qpos for drawer open
+        target_qlimits = self.dishwasher.get_qlimits()
+        qmin, qmax = target_qlimits[:, 0, 0], target_qlimits[:, 0, 1]
+        self.target_qpos = qmin + (qmax - qmin) * self.min_open_frac
+
+    def _initialize_episode(self, env_idx: torch.Tensor, options: Dict):
+        device = self.device
+        with torch.device(device):
+            b = len(env_idx)
+
+            # Initialize table scene
+            self.table_scene.initialize(env_idx)
+
+            # Get table top z
+            table_p_arr = np.asarray(self.table_scene.table.pose.p).ravel()
+            table_z = float(table_p_arr[-1])
+            table_top_z = table_z + float(self.table_scene.table_height)
+
+            # Position dishwasher on table (to the right side)
+            dishwasher_pos = torch.zeros((b, 3), device=device)
+            dishwasher_pos[:, 0] = 0.0  # In front of robot
+            dishwasher_pos[:, 1] = 0.2  # To the right
+            dishwasher_pos[:, 2] = table_top_z + 0.15  # On table surface
+
+            # Rotate dishwasher to face the robot (front facing -Y direction)
+            # The URDF has a rotation built in, we want the door to face the robot
+            dishwasher_quat = torch.zeros((b, 4), device=device)
+            dishwasher_quat[:, 0] = 1.0  # w=1, identity rotation
+
+            dishwasher_pose = Pose.create_from_pq(p=dishwasher_pos, q=dishwasher_quat)
+            self.dishwasher.set_pose(dishwasher_pose)
+
+            # Start with drawer slightly open (15% open) so gripper can hook the lip
+            qlimits = self.dishwasher.get_qlimits()
+            qmin, qmax = qlimits[env_idx, :, 0], qlimits[env_idx, :, 1]
+            initial_qpos = qmin + (qmax - qmin) * 0.15  # 15% open
+            self.dishwasher.set_qpos(initial_qpos)
+            self.dishwasher.set_qvel(self.dishwasher.qpos[env_idx] * 0)
+
+            # Position plate on table (to the left side, near robot)
+            plate_x = -0.35 + (torch.rand(b, device=device) - 0.5) * 0.1
+            plate_y = -0.15 + (torch.rand(b, device=device) - 0.5) * 0.1
+
+            xyz = torch.zeros((b, 3), device=device)
+            xyz[:, 0] = plate_x
+            xyz[:, 1] = plate_y
+            plate_half_height = self._plate_total_height / 2.0
+            xyz[:, 2] = table_top_z + plate_half_height + self._plate_spawn_buffer
+
+            # Random plate yaw
+            plate_yaw = torch.rand(b, device=device) * 2 * np.pi
+            flat_quat = torch.zeros((b, 4), device=device)
+            flat_quat[:, 0] = torch.cos(plate_yaw / 2)
+            flat_quat[:, 3] = torch.sin(plate_yaw / 2)
+
+            plate_pose = Pose.create_from_pq(p=xyz, q=flat_quat)
+            self.plate.set_pose(plate_pose)
+
+            # Let physics settle
+            for _ in range(50):
+                self.scene.step()
+
+            # Reset plate to stable pose
+            xyz[:, 2] = table_top_z + plate_half_height + self._plate_spawn_buffer
+            plate_pose = Pose.create_from_pq(p=xyz, q=flat_quat)
+            self.plate.set_pose(plate_pose)
+
+            # Zero velocities
+            zero_velocity = torch.zeros((b, 3), device=device)
+            self.plate.set_linear_velocity(zero_velocity)
+            self.plate.set_angular_velocity(zero_velocity)
+
+    def evaluate(self):
+        # Check if drawer is open enough
+        qpos = self.dishwasher.qpos
+        if qpos.ndim > 1:
+            qpos = qpos.squeeze(-1)
+
+        qlimits = self.dishwasher.get_qlimits()
+        qmin, qmax = qlimits[:, 0, 0], qlimits[:, 0, 1]
+        open_frac = (qpos - qmin) / (qmax - qmin + 1e-6)
+        drawer_open = open_frac >= self.min_open_frac
+
+        # Check if plate is on/near the dishwasher
+        plate_pos = self.plate.pose.p
+        dishwasher_pos = self.dishwasher.pose.p
+
+        # Plate should be within the dishwasher bounds (roughly)
+        plate_near_dishwasher_x = torch.abs(plate_pos[:, 0] - dishwasher_pos[:, 0]) < 0.2
+        plate_near_dishwasher_y = torch.abs(plate_pos[:, 1] - dishwasher_pos[:, 1]) < 0.2
+        plate_above_dishwasher = plate_pos[:, 2] > dishwasher_pos[:, 2] - 0.1
+        plate_not_too_high = plate_pos[:, 2] < dishwasher_pos[:, 2] + 0.2
+        plate_on_shelf = plate_near_dishwasher_x & plate_near_dishwasher_y & plate_above_dishwasher & plate_not_too_high
+
+        # Plate should be flat (not vertical)
+        rot_mats = quaternion_to_matrix(self.plate.pose.q)
+        plate_norm = rot_mats[..., 2]
+        plate_flat = torch.abs(plate_norm[..., 2]) >= 0.8  # Z component of normal should be high
+
+        # Check if released and static
+        is_grasped = self.agent.is_grasping(self.plate)
+        is_static = self.plate.is_static(lin_thresh=0.02, ang_thresh=0.4)
+
+        success = drawer_open & plate_on_shelf & plate_flat & is_static & ~is_grasped
+
+        return {
+            "success": success,
+            "drawer_open": drawer_open,
+            "plate_on_shelf": plate_on_shelf,
+            "plate_flat": plate_flat,
+            "is_static": is_static,
+            "is_grasped": is_grasped,
+            "open_frac": open_frac,
+        }
+
+    def _get_obs_extra(self, info: Dict):
+        plate_pose = self.plate.pose
+        dishwasher_pose = self.dishwasher.pose
+        obs = {
+            "plate_pos": plate_pose.p,
+            "plate_quat": plate_pose.q,
+            "dishwasher_pos": dishwasher_pose.p,
+            "dishwasher_quat": dishwasher_pose.q,
+            "dishwasher_qpos": self.dishwasher.qpos,
+        }
+        if "state" in self.obs_mode:
+            obs.update(
+                plate_to_dishwasher=plate_pose.p - dishwasher_pose.p,
+                tcp_to_plate=plate_pose.p - self.agent.tcp_pose.p,
+            )
+        return obs
+
+    def compute_dense_reward(self, obs: Any, action: torch.Tensor, info: Dict) -> torch.Tensor:
+        """Compute dense reward for the task."""
+        # Phase 1: Open the drawer
+        open_frac = info["open_frac"]
+        drawer_reward = open_frac * 2.0
+
+        # Phase 2: Place plate on dishwasher (only reward when drawer is open)
+        plate_pos = self.plate.pose.p
+        dishwasher_pos = self.dishwasher.pose.p
+        dist_to_dishwasher = torch.linalg.norm(plate_pos - dishwasher_pos, axis=1)
+        placement_reward = torch.where(
+            info["drawer_open"],
+            (1.0 - torch.tanh(2.0 * dist_to_dishwasher)) * 2.0,
+            torch.zeros_like(dist_to_dishwasher),
+        )
+
+        # Release reward
+        release_reward = torch.where(
+            info["plate_on_shelf"] & ~info["is_grasped"],
+            torch.ones_like(dist_to_dishwasher),
+            torch.zeros_like(dist_to_dishwasher),
+        )
+
+        # Success bonus
+        success_reward = info["success"].float() * 5.0
+
+        reward = drawer_reward + placement_reward + release_reward + success_reward
+        return reward
+
+    def compute_normalized_dense_reward(self, obs: Any, action: torch.Tensor, info: Dict) -> torch.Tensor:
+        return self.compute_dense_reward(obs, action, info) / 10.0

--- a/mani_skill/examples/motionplanning/panda/solutions/load_dishwasher.py
+++ b/mani_skill/examples/motionplanning/panda/solutions/load_dishwasher.py
@@ -1,0 +1,104 @@
+import numpy as np
+
+from mani_skill.envs.tasks.tabletop.load_dishwasher import LoadDishwasherEnv
+from mani_skill.examples.motionplanning.panda.motionplanner import (
+    PandaArmMotionPlanningSolver,
+)
+
+
+def solve(env: LoadDishwasherEnv, seed=None, debug=False, vis=False):
+    env.reset(seed=seed)
+    assert env.unwrapped.control_mode in [
+        "pd_joint_pos",
+        "pd_joint_pos_vel",
+    ], env.unwrapped.control_mode
+
+    planner = PandaArmMotionPlanningSolver(
+        env,
+        debug=debug,
+        vis=vis,
+        base_pose=env.unwrapped.agent.robot.pose,
+        visualize_target_grasp_pose=vis,
+        print_env_info=False,
+    )
+
+    env_sim = env.unwrapped
+
+    # Get drawer link position as reference
+    drawer_link = env_sim.dishwasher._objs[0].links[2]
+    drawer_pos = np.array(drawer_link.pose.p)
+
+    # Grasp orientation: approach from top, fingers close front-to-back
+    approaching = np.array([0, 0, -1])  # approach from above
+    closing = np.array([1, 0, 0])        # fingers close in X direction
+
+    # Pre-grasp position: above the lip
+    pregrasp_pos = drawer_pos.copy()
+    pregrasp_pos[0] -= 0.015
+    pregrasp_pos[1] -= 0.03  # at the lip edge
+    pregrasp_pos[2] += 0.25  # high above
+    pregrasp_pose = env_sim.agent.build_grasp_pose(approaching, closing, pregrasp_pos)
+
+    # Grasp position: relative to pre-grasp, move down to grip the lip
+    grasp_pos = pregrasp_pos.copy()
+    grasp_pos[2] -= 0.04  # move down 2cm from pre-grasp
+    grasp_pose = env_sim.agent.build_grasp_pose(approaching, closing, grasp_pos)
+
+    if debug:
+        print(f"Drawer pos: {drawer_pos}")
+        print(f"Pregrasp pos: {pregrasp_pos}")
+        print(f"Grasp pos: {grasp_pos}")
+        print(f"Distance (Z): {pregrasp_pos[2] - grasp_pos[2]:.2f}m")
+
+    # Step 1: Move to pre-grasp position
+    planner.open_gripper(t=30)
+    res = planner.move_to_pose_with_RRTConnect(pregrasp_pose)
+    if res == -1:
+        planner.close()
+        return res
+
+    if debug:
+        print("Step 1: At pre-grasp position")
+
+    # Step 2: Move forward so open gripper wraps around the lip
+    planner.open_gripper(t=10)
+    res = planner.move_to_pose_with_screw(grasp_pose)
+    if res == -1:
+        planner.close()
+        return res
+
+    if debug:
+        print("Step 2: Gripper wrapped around lip")
+
+    # Step 3: Close gripper hard
+    planner.close_gripper(t=30, gripper_state=-1.0)
+
+    if debug:
+        print("Step 3: Gripper closed")
+
+    # Step 4: Pull back toward robot base (-X direction)
+    pull_pos = grasp_pos.copy()
+    pull_pos[0] -= 0.20  # pull back 20cm toward robot
+    pull_pose = env_sim.agent.build_grasp_pose(approaching, closing, pull_pos)
+
+    res = planner.move_to_pose_with_screw(pull_pose)
+    if res == -1:
+        if debug:
+            print("Pull failed")
+        planner.close()
+        return res
+
+    if debug:
+        print("Step 4: Pulled back")
+
+    # Hold position
+    robot_qpos = env_sim.agent.robot.get_qpos()[0, : len(planner.planner.joint_vel_limits)].cpu().numpy()
+    for _ in range(60):
+        if planner.control_mode == "pd_joint_pos":
+            action = np.hstack([robot_qpos, -1.0])
+        else:
+            action = np.hstack([robot_qpos, robot_qpos * 0, -1.0])
+        env_sim.step(action)
+
+    planner.close()
+    return res

--- a/mani_skill/examples/motionplanning/panda/solutions/open_cabinet.py
+++ b/mani_skill/examples/motionplanning/panda/solutions/open_cabinet.py
@@ -270,7 +270,7 @@ def _open_cabinet_with_planner(
         )
 
         # Try different pull-back distances with screw motion only
-        res = -1 
+        res = -1
         for pull_back in pull_offsets:
             pull_pose = target_pose * sapien.Pose([0, 0, pull_back])
             res = planner.move_to_pose_with_screw(pull_pose)


### PR DESCRIPTION
## Summary
- Vectorizes 7 colosseum_v2 environments to work with the CUDA sim backend and multiple parallel environments (`num_envs > 1`)
- Key fixes: expand single-model data (cabinet_zs, handle_link_pos) to num_envs, use raw SAPIEN entities for pre-GPU-init operations, replace numpy ops with torch tensor ops, move locked motion axis setup before GPU init

### Environments fixed
- `PickDishFromRack-v1`
- `PlaceDishInRack-v1`
- `HammerNail-v1`
- `OpenCabinet-v1`
- `CookItemInPan-v1`
- `PickCubeFromDrawer-v1`
- `PlaceCubeInDrawer-v1`
